### PR TITLE
README: repository moved

### DIFF
--- a/README
+++ b/README
@@ -12,8 +12,8 @@ The font maps were written by several people, including
   Takuji Tanaka
   Saito Shuzaburo
   Norbert Preining
-and are now maintained in the tug.org subversion repository:
-  https://git.gitorious.org/tlptexlive/jfontmaps.git
+and are now maintained in the github.com git repository:
+  https://github.com/texjporg/jfontmaps
 
 Families, support, and necessary font files
 ===========================================


### PR DESCRIPTION
I cannot find the repository on gitorious.
This repository (texjporg/jfontmaps in github) seem to be current main repository, right?
