### PR TITLE
BIZ UD fonts

### DIFF
--- a/README
+++ b/README
@@ -89,6 +89,12 @@ D ms-osx - MS Mincho and MS Gothic, shipped with Office for Mac
     MS-Mincho.ttf      (<= "MS Mincho.ttf")
     MS-Gothic.ttf      (<= "MS Gothic.ttf")
 
+4 bizud - BIZ UD fonts by Morisawa Inc., bundled with Win 10
+        October 2018 Update.
+    BIZ-UDMinchoM.ttc
+    BIZ-UDGothicR.ttc
+    BIZ-UDGothicB.ttc
+
 4 yu-win - Yu Mincho and Yu Gothic fonts by Jiyu-koubou LTD.,
        bundled with Win 8.1.
     yumin.ttf

--- a/maps/bizud/otf-bizud.map
+++ b/maps/bizud/otf-bizud.map
@@ -1,0 +1,80 @@
+
+% TEXT, 90JIS
+hminl-h	H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+hminl-v	V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+hminr-h	H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+hminr-v	V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+hminb-h	H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+hminb-v	V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+hgothr-h	H	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+hgothr-v	V	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+hgothb-h	H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+hgothb-v	V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+hgotheb-h	H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+hgotheb-v	V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+hmgothr-h	H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+hmgothr-v	V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+
+% TEXT, JIS04
+hminln-h	H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+hminln-v	V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+hminrn-h	H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+hminrn-v	V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+hminbn-h	H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+hminbn-v	V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+hgothrn-h	H	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+hgothrn-v	V	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+hgothbn-h	H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+hgothbn-v	V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+hgothebn-h	H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+hgothebn-v	V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+hmgothrn-h	H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+hmgothrn-v	V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+
+% CID
+otf-cjml-h	Identity-H	:0:BIZ-UDMinchoM.ttc/AJ16 %!PS BIZ-UDMincho-Medium
+otf-cjml-v	Identity-V	:0:BIZ-UDMinchoM.ttc/AJ16 %!PS BIZ-UDMincho-Medium
+otf-cjmr-h	Identity-H	:0:BIZ-UDMinchoM.ttc/AJ16 %!PS BIZ-UDMincho-Medium
+otf-cjmr-v	Identity-V	:0:BIZ-UDMinchoM.ttc/AJ16 %!PS BIZ-UDMincho-Medium
+otf-cjmb-h	Identity-H	:0:BIZ-UDMinchoM.ttc/AJ16 %!PS BIZ-UDMincho-Medium
+otf-cjmb-v	Identity-V	:0:BIZ-UDMinchoM.ttc/AJ16 %!PS BIZ-UDMincho-Medium
+otf-cjgr-h	Identity-H	:0:BIZ-UDGothicR.ttc/AJ16 %!PS BIZ-UDGothic
+otf-cjgr-v	Identity-V	:0:BIZ-UDGothicR.ttc/AJ16 %!PS BIZ-UDGothic
+otf-cjgb-h	Identity-H	:0:BIZ-UDGothicB.ttc/AJ16 %!PS BIZ-UDGothic-Bold
+otf-cjgb-v	Identity-V	:0:BIZ-UDGothicB.ttc/AJ16 %!PS BIZ-UDGothic-Bold
+otf-cjge-h	Identity-H	:0:BIZ-UDGothicB.ttc/AJ16 %!PS BIZ-UDGothic-Bold
+otf-cjge-v	Identity-V	:0:BIZ-UDGothicB.ttc/AJ16 %!PS BIZ-UDGothic-Bold
+otf-cjmgr-h	Identity-H	:0:BIZ-UDGothicB.ttc/AJ16 %!PS BIZ-UDGothic-Bold
+otf-cjmgr-v	Identity-V	:0:BIZ-UDGothicB.ttc/AJ16 %!PS BIZ-UDGothic-Bold
+
+% Unicode 90JIS
+otf-ujml-h	UniJIS-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+otf-ujml-v	UniJIS-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+otf-ujmr-h	UniJIS-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+otf-ujmr-v	UniJIS-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+otf-ujmb-h	UniJIS-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+otf-ujmb-v	UniJIS-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+otf-ujgr-h	UniJIS-UTF16-H	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+otf-ujgr-v	UniJIS-UTF16-V	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+otf-ujgb-h	UniJIS-UTF16-H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+otf-ujgb-v	UniJIS-UTF16-V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+otf-ujge-h	UniJIS-UTF16-H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+otf-ujge-v	UniJIS-UTF16-V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+otf-ujmgr-h	UniJIS-UTF16-H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+otf-ujmgr-v	UniJIS-UTF16-V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+
+% Unicode JIS04
+otf-ujmln-h	UniJIS2004-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+otf-ujmln-v	UniJIS2004-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+otf-ujmrn-h	UniJIS2004-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+otf-ujmrn-v	UniJIS2004-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+otf-ujmbn-h	UniJIS2004-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+otf-ujmbn-v	UniJIS2004-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+otf-ujgrn-h	UniJIS2004-UTF16-H	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+otf-ujgrn-v	UniJIS2004-UTF16-V	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+otf-ujgbn-h	UniJIS2004-UTF16-H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+otf-ujgbn-v	UniJIS2004-UTF16-V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+otf-ujgen-h	UniJIS2004-UTF16-H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+otf-ujgen-v	UniJIS2004-UTF16-V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+otf-ujmgrn-h	UniJIS2004-UTF16-H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+otf-ujmgrn-v	UniJIS2004-UTF16-V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold

--- a/maps/bizud/otf-up-bizud.map
+++ b/maps/bizud/otf-up-bizud.map
@@ -1,0 +1,32 @@
+
+% TEXT, 90JIS
+uphminl-h	UniJIS-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+uphminl-v	UniJIS-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+uphminr-h	UniJIS-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+uphminr-v	UniJIS-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+uphminb-h	UniJIS-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+uphminb-v	UniJIS-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+uphgothr-h	UniJIS-UTF16-H	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+uphgothr-v	UniJIS-UTF16-V	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+uphgothb-h	UniJIS-UTF16-H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+uphgothb-v	UniJIS-UTF16-V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+uphgotheb-h	UniJIS-UTF16-H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+uphgotheb-v	UniJIS-UTF16-V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+uphmgothr-h	UniJIS-UTF16-H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+uphmgothr-v	UniJIS-UTF16-V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+
+% TEXT, JIS04
+uphminln-h	UniJIS2004-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+uphminln-v	UniJIS2004-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+uphminrn-h	UniJIS2004-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+uphminrn-v	UniJIS2004-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+uphminbn-h	UniJIS2004-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+uphminbn-v	UniJIS2004-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+uphgothrn-h	UniJIS2004-UTF16-H	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+uphgothrn-v	UniJIS2004-UTF16-V	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+uphgothbn-h	UniJIS2004-UTF16-H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+uphgothbn-v	UniJIS2004-UTF16-V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+uphgothebn-h	UniJIS2004-UTF16-H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+uphgothebn-v	UniJIS2004-UTF16-V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+uphmgothrn-h	UniJIS2004-UTF16-H	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold
+uphmgothrn-v	UniJIS2004-UTF16-V	:0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold

--- a/maps/bizud/ptex-bizud.map
+++ b/maps/bizud/ptex-bizud.map
@@ -1,0 +1,4 @@
+rml	H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+rmlv	V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+gbm	H	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+gbmv	V	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic

--- a/maps/bizud/uptex-bizud.map
+++ b/maps/bizud/uptex-bizud.map
@@ -1,0 +1,10 @@
+urml	UniJIS-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+urmlv	UniJIS-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+ugbm	UniJIS-UTF16-H	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+ugbmv	UniJIS-UTF16-V	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+uprml-h	UniJIS-UTF16-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+uprml-v	UniJIS-UTF16-V	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+upgbm-h	UniJIS-UTF16-H	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+upgbm-v	UniJIS-UTF16-V	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic
+uprml-hq	UniJIS-UCS2-H	:0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium
+upgbm-hq	UniJIS-UCS2-H	:0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic

--- a/tools/mkmap-ja.lua
+++ b/tools/mkmap-ja.lua
@@ -43,6 +43,18 @@ local foundry = {
       mgr='MS-Gothic.ttf',
       {''},
    },
+   ['bizud']   = {
+      noncid = true,
+      ml=':0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium',
+      mr=':0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium',
+      mb=':0:BIZ-UDMinchoM.ttc %!PS BIZ-UDMincho-Medium',
+      gr=':0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic',
+      gru=':0:BIZ-UDGothicR.ttc %!PS BIZ-UDGothic',
+      gb=':0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold',
+      ge=':0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold',
+      mgr=':0:BIZ-UDGothicB.ttc %!PS BIZ-UDGothic-Bold',
+      {''},
+   },
    ['yu-win']   = {
       noncid = true,
       ml='yuminl.ttf %!PS YuMincho-Light',


### PR DESCRIPTION
WIndows 10 October 2018 Update に収録された BIZ UD フォント（モリサワ）を使う設定です．
（これらは "Preview & Print" embedding only ライセンスのようですが）