### PR TITLE
kanji-config-updmap.pl: fix kpse_miscfont()

### DIFF
--- a/script/kanji-config-updmap.pl
+++ b/script/kanji-config-updmap.pl
@@ -315,7 +315,7 @@ sub kpse_miscfont {
   # first, prioritize GitHub repository diretory structure
   $foo = "database/$file" if (-f "database/$file");
   if ($foo eq "") {
-    chomp(my $foo = `kpsewhich -format=miscfont $file`);
+    chomp($foo = `kpsewhich -format=miscfont $file`);
   }
   return $foo;
 }


### PR DESCRIPTION
8e4a58953a4a67f1e4c0b82497420fd552f1d7da で加えられた変更で，`$foo` に `my` がついているために，この変更が `if` 文のスコープ内に閉じ込められ，`kpsewhich` の結果が `return` 文に回らなくなっていましたので，`my` を外しました。